### PR TITLE
RabbitMQ 다중 노드 클러스터 구성 (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 rabbitmq/data/
+rabbitmq-cluster/data/
 .env

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -1,8 +1,12 @@
-version: "2.4"
+version: "3.9"
 services:
   haproxy:
     image: haproxy:2.4
-    container_name: haproxy
+    user: haproxy
+    entrypoint: >
+      sh -c "
+        exec haproxy -f /usr/local/etc/haproxy/haproxy.cfg
+      "
     depends_on:
       rabbit1:
         condition: service_healthy
@@ -10,33 +14,24 @@ services:
         condition: service_healthy
       rabbit3:
         condition: service_healthy
+    tmpfs:
+      - /tmp/haproxy:mode=1777,size=16m   # ← 핵심
     volumes:
+      # (★) 호스트의 cfg → 컨테이너 cfg
       - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
-      - ./haproxy/queue_ports.map:/etc/haproxy/queue_ports.map:ro
-      - ./haproxy/port_map.map:/etc/haproxy/port_map.map
-      - /var/run/haproxy.sock:/var/run/haproxy.sock
     ports:
-      - "50000-50100:50000-50100"
+      - "5672:5672"
+      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     networks:
-      - elk-net
-
-  map-updater:
-    build:
-      context: ./haproxy
-      dockerfile: Dockerfile.map
-    container_name: haproxy-map-updater
-    depends_on:
-      haproxy:
-        condition: service_started
-    volumes:
-      - ./haproxy/queue_ports.map:/etc/haproxy/queue_ports.map:ro
-      - ./haproxy/port_map.map:/etc/haproxy/port_map.map
-      - /var/run/haproxy.sock:/var/run/haproxy.sock
-    entrypoint: ["/update_map.sh"]
+      elk-net:
+        aliases:
+          - haproxy
 
   # ─ RabbitMQ 3-node Quorum cluster ──────────────────────────
   rabbit1:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit1
     container_name: rabbit1
     environment:
@@ -45,30 +40,29 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit1
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit1:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit1:/var/lib/rabbitmq/mnesia
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
-    ports:
-      - "${EXTERNAL_HAPROXY_PORT}:5672"
-      - "${EXTERNAL_RABBITMQ_MANAGEMENT_PORT}:15672"
     networks:
       elk-net:
         aliases:
           - rabbit1
   rabbit2:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit2
     container_name: rabbit2
     depends_on:
       rabbit1:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -79,8 +73,9 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit2
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit2:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit2:/var/lib/rabbitmq/mnesia
+      
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&
@@ -94,15 +89,18 @@ services:
       elk-net:
         aliases:
           - rabbit2
+          
   rabbit3:
-    image: heidiks/rabbitmq-delayed-message-exchange:3.12.2-management
+    build:
+      context: ./rabbitmq-cluster
+      dockerfile: Dockerfile
     hostname: rabbit3
     container_name: rabbit3
     depends_on:
       rabbit1:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -113,8 +111,8 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=${RABBITMQ_NODENAME_PREFIX}rabbit3
     volumes:
-      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./rabbitmq/data/rabbit3:/var/lib/rabbitmq/mnesia
+      - ./rabbitmq-cluster/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./rabbitmq-cluster/data/rabbit3:/var/lib/rabbitmq/mnesia
     entrypoint: >
       bash -c "
         rabbitmq-server -detached &&
@@ -139,22 +137,37 @@ services:
       rabbit3:
         condition: service_healthy
     volumes:
-      - ./rabbitmq/definitions.json:/definitions.json:ro
+      - ./rabbitmq-cluster/definitions.json:/definitions.json:ro
     entrypoint: >
       sh -c '
-        echo "$(date) waiting for RabbitMQ cluster…";
-        until curl -s -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" \
-            http://rabbit1:15672/api/nodes | grep -q rabbit@rabbit3; do
-          sleep 5;
-        done;
-        echo "$(date) importing definitions…";
-        curl -u "${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}" \
-             -H "Content-Type: application/json" \
-             -X POST \
-             --data-binary @/definitions.json \
-             http://rabbit1:15672/api/definitions;
-        echo "$(date) done.";
+        set -eu
+        USER=$${RABBITMQ_DEFAULT_USER:-guest}
+        PASS=$${RABBITMQ_DEFAULT_PASS:-guest}
+        HOST="rabbit1:15672"
+
+        echo "$$(date) ⏳  waiting for rabbit1/2/3 to join…"
+        while :; do
+          json=$$(curl -s -u "$$USER:$$PASS" "http://$$HOST/api/nodes" || true)
+
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit1\"" || { sleep 5; continue; }
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit2\"" || { sleep 5; continue; }
+          echo "$$json" | grep -q "\"name\":\"rabbit@rabbit3\"" || { sleep 5; continue; }
+
+          break
+        done
+
+        echo "Waiting for 60 seconds...."
+        sleep 60
+
+        echo "$$(date) ✅  cluster ready. importing definitions…"
+        curl -sS -u "$$USER:$$PASS" -H "Content-Type: application/json" \
+            -X POST --data-binary @/definitions.json \
+            "http://$$HOST/api/definitions"
+        echo "$$(date) 🎉  done."
       '
+    networks:
+      - elk-net
+
   # ─ Elasticsearch ───────────────────────────────────────────
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
@@ -223,7 +236,7 @@ services:
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "
@@ -239,14 +252,14 @@ services:
       - rabbit3
       - es-init
     volumes:
-      - ./logstash/pipeline1:/usr/share/logstash/pipeline
+      - ./logstash/pipeline2:/usr/share/logstash/pipeline
       - ./wait-for-it.sh:/usr/local/bin/wait-for-it.sh
     entrypoint: >
       bash -c "
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "
@@ -262,14 +275,14 @@ services:
       - rabbit3
       - es-init
     volumes:
-      - ./logstash/pipeline1:/usr/share/logstash/pipeline
+      - ./logstash/pipeline3:/usr/share/logstash/pipeline
       - ./wait-for-it.sh:/usr/local/bin/wait-for-it.sh
     entrypoint: >
       bash -c "
         # 1) ES 준비 대기
         /usr/local/bin/wait-for-it.sh elasticsearch:9200 --strict --timeout=120 &&
         # 2) RabbitMQ 준비 대기
-        /usr/local/bin/wait-for-it.sh rabbitmq:5672 --strict --timeout=60 &&
+        /usr/local/bin/wait-for-it.sh haproxy:5672 --strict --timeout=60 &&
         # 3) 준비되면 Logstash 진짜 진입점 실행
         exec /usr/local/bin/docker-entrypoint
       "

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,29 +1,48 @@
 global
     log stdout format raw local0
-    stats socket /var/run/haproxy.sock mode 600 level admin
+    stats socket /tmp/haproxy/haproxy.sock mode 600 level admin
 
 defaults
-    mode    tcp
+    log             global
+    mode            tcp
     timeout connect 5s
     timeout client  30s
     timeout server  30s
+    retries         2                      # 연결 실패 시 최대 2회 재시도
+    option redispatch                       # 첫 시도 실패 시 다른 서버로 재배치
+    retry-on        conn-failure empty-response response-timeout
 
-frontend amqp
-    bind *:50000-50100
+frontend amqp_global
+    bind *:5672
     mode tcp
     option tcplog
-    tcp-request inspect-delay 5s
-    tcp-request content accept if WAIT_END
-    default_backend amqp_leader
+    default_backend rabbit_cluster
 
-backend amqp_leader
-    mode tcp
-    balance static-rr
-    # 서버 ID는 map에서 나오는 이름과 일치시킵니다
-    server rabbit1 rabbit1:5672 check
-    server rabbit2 rabbit2:5672 check
-    server rabbit3 rabbit3:5672 check
+backend rabbit_cluster
+    mode    tcp
+    balance roundrobin                     # 또는 leastconn
+    option  tcp-check
+    server  rabbit1 rabbit1:5672 check inter 1s fall 2 rise 1
+    server  rabbit2 rabbit2:5672 check inter 1s fall 2 rise 1
+    server  rabbit3 rabbit3:5672 check inter 1s fall 2 rise 1
 
-    # 항상 map에서 지정된 서버로만 연결
-    # map 파일 key=dst_port, value=serverID
-    use-server %[dst_port,map(/etc/haproxy/port_map.map)]
+# =================================================================
+# RabbitMQ Management UI 트래픽 (포트 15672) - 신규 추가 (순차 접속)
+# =================================================================
+
+frontend rabbitmq_mgmt_ui
+    bind *:15672
+    mode http                                   # <-- 다시 http 모드로 변경!
+    default_backend rabbit_mgmt_cluster
+
+backend rabbit_mgmt_cluster
+    mode    http                                # <-- 다시 http 모드로 변경!
+    balance first
+    # Basic 인증 헤더가 포함된, 올바른 HTTP 헬스체크 사용
+    # 'guest:guest'를 Base64 인코딩한 'Z3Vlc3Q6Z3Vlc3Q=' 사용
+    option httpchk GET /api/aliveness-test/%2f HTTP/1.1\r\nHost:\ localhost\r\nAuthorization:\ Basic\ Z3Vlc3Q6Z3Vlc3Q=
+
+    # 서버 목록은 그대로
+    server  rabbit1 rabbit1:15672 check inter 1s fall 2 rise 1
+    server  rabbit2 rabbit2:15672 check inter 1s fall 2 rise 1 backup
+    server  rabbit3 rabbit3:15672 check inter 1s fall 2 rise 1 backup

--- a/logstash/pipeline1/logstash.conf
+++ b/logstash/pipeline1/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_1"
     durable  => true
     codec    => "json"

--- a/logstash/pipeline2/logstash.conf
+++ b/logstash/pipeline2/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_2"
     durable  => true
     codec    => "json"

--- a/logstash/pipeline3/logstash.conf
+++ b/logstash/pipeline3/logstash.conf
@@ -1,6 +1,7 @@
 input {
   rabbitmq {
-    host     => "rabbitmq"
+    host     => "haproxy"
+    heartbeat => 30
     queue    => "logs_pipeline_3"
     durable  => true
     codec    => "json"

--- a/rabbitmq-cluster/Dockerfile
+++ b/rabbitmq-cluster/Dockerfile
@@ -1,0 +1,5 @@
+# haproxy/rabbitmq/Dockerfile
+FROM rabbitmq:3.12.2-management
+
+# 플러그인 설치 (내장 플러그인이므로 enable만)
+RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange

--- a/rabbitmq-cluster/definitions.json
+++ b/rabbitmq-cluster/definitions.json
@@ -19,13 +19,12 @@
   "policies": [],
   "exchanges": [
     {
-      "name": "app_logs_exchange",
-      "type": "direct",
-      "durable": true,
-      "vhost": "/",
-      "auto_delete": false,
-      "internal": false,
-      "arguments": {}
+    "name": "app_logs_exchange",           
+    "type": "x-consistent-hash",        
+    "durable": true,
+    "vhost": "/",
+    "auto_delete": false,
+    "internal": false
     },
     {
       "name": "worker_tasks_exchange",
@@ -69,21 +68,21 @@
       "vhost": "/",
       "destination": "logs_pipeline_1",
       "destination_type": "queue",
-      "routing_key": "logs_1"
+      "routing_key": "1"
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_2",
       "destination_type": "queue",
-      "routing_key": "logs_2"
+      "routing_key": "1"
     },
     {
       "source": "app_logs_exchange",
       "vhost": "/",
       "destination": "logs_pipeline_3",
       "destination_type": "queue",
-      "routing_key": "logs_3"
+      "routing_key": "1"
     },
     {
       "source": "worker_tasks_exchange",

--- a/rabbitmq-cluster/rabbitmq.conf
+++ b/rabbitmq-cluster/rabbitmq.conf
@@ -1,3 +1,5 @@
 # RabbitMQ 기본 AMQP/HTTP 포트
 listeners.tcp.default = 5672
 management.listener.port = 15672
+queue_leader_locator = balanced
+# management.load_definitions = /etc/rabbitmq/definitions.json


### PR DESCRIPTION
* [fix] HAProxy 라우팅 변경 + RabbitMQ 클러스터 변경

* fix: haproxy depends_on healthcheck 지워진 것 복원

* fix: rabbitMQ healthcheck 방식 변경

* chore: logstash host 이름 haproxy로 변경

* fix: rabbitmq plugin enable 및 app_logs_exchange hash 사용하게 수정

* fix: rabbitmq heartbeat 주기 변경

* fix: logstash output과 binding key 형식 조정

* fix: 최초 node 생성 시 definition.json 이용하지 않도록 삭제

* fix: RabbitMQ 모니터링 UI HAProxy 쓰도록 변경